### PR TITLE
MSVC fix for COUNT_LEADING_ZEROS

### DIFF
--- a/lib/count-leading-zeros.h
+++ b/lib/count-leading-zeros.h
@@ -44,7 +44,8 @@ _GL_INLINE_HEADER_BEGIN
     do                                                                  \
       {                                                                 \
         unsigned long result;                                           \
-        return MSC_BUILTIN (&result, x) ? result : CHAR_BIT * sizeof x; \
+        unsigned long bitsize = CHAR_BIT * sizeof x;                    \ 
+        return MSC_BUILTIN (&result, x) ? result^(bitsize-1) : bitsize; \
       }                                                                 \
     while (0)
 #else


### PR DESCRIPTION
_BitScanReverse returns the position of the first bit set.
It requires one more step to get the number of leading zeroes.
see https://chessprogramming.wikispaces.com/BitScan#Bitscan versus Zero Count
